### PR TITLE
De-duplicate _tokenPerShare functions and add error code mappings

### DIFF
--- a/SorbettoFragola.sol
+++ b/SorbettoFragola.sol
@@ -413,7 +413,8 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         uint256 amount0,
         uint256 amount1,
         bytes calldata data
-    ) external onlyPool {
+    ) external {
+        require(msg.sender == address(pool03), "FP");
         MintCallbackData memory decoded = abi.decode(data, (MintCallbackData));
         if (amount0 > 0) pay(token0, decoded.payer, msg.sender, amount0);
         if (amount1 > 0) pay(token1, decoded.payer, msg.sender, amount1);
@@ -428,9 +429,9 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         int256 amount0,
         int256 amount1,
         bytes calldata _data
-    ) external onlyPool {
-        // swaps entirely within 0-liquidity regions are not supported
-        require(amount0 > 0 || amount1 > 0, "S0L");
+    ) external {
+        require(msg.sender == address(pool03), "FP");
+        require(amount0 > 0 || amount1 > 0); // swaps entirely within 0-liquidity regions are not supported
         SwapCallbackData memory data = abi.decode(_data, (SwapCallbackData));
         bool zeroForOne = data.zeroForOne;
 
@@ -530,11 +531,6 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
     // when it's too volatile.
     modifier checkDeviation() {
         pool03.checkDeviation(ISorbettoStrategy(strategy).maxTwapDeviation(), ISorbettoStrategy(strategy).twapDuration());
-        _;
-    }
-
-    modifier onlyPool() {
-        require(msg.sender == address(pool03), "FP");
         _;
     }
     

--- a/SorbettoFragola.sol
+++ b/SorbettoFragola.sol
@@ -542,8 +542,8 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         (uint256 collect0, uint256 collect1) = _earnFees();
         
         
-        token0PerShareStored = _token0PerShare(collect0);
-        token1PerShareStored = _token1PerShare(collect1);
+        token0PerShareStored = _tokenPerShare(collect0, token0PerShareStored);
+        token1PerShareStored = _tokenPerShare(collect1, token1PerShareStored);
 
         if (account != address(0)) {
             UserInfo storage user = userInfo[msg.sender];
@@ -575,32 +575,18 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
             .add(user.token1Rewards);
     }
     
-    // Calculates how much token0 is provied per LP token 
-    function _token0PerShare(uint256 collected0) internal view returns (uint256) {
+    // Calculates how much token is provided per LP token 
+    function _tokenPerShare(uint256 collected, uint256 tokenPerShareStored) internal view returns (uint256) {
         uint _totalSupply = totalSupply();
         if (_totalSupply > 0) {
-            return token0PerShareStored
+            return tokenPerShareStored
             .add(
-                collected0
+                collected
                 .mul(1e18)
                 .unsafeDiv(_totalSupply)
             );
         }
-        return token0PerShareStored;
-    }
-    
-    // Calculates how much token1 is provied per LP token 
-    function _token1PerShare(uint256 collected1) internal view returns (uint256) {
-        uint _totalSupply = totalSupply();
-        if (_totalSupply > 0) {
-            return token1PerShareStored
-            .add(
-                collected1
-                .mul(1e18)
-                .unsafeDiv(_totalSupply)
-            );
-        }
-        return token1PerShareStored;
+        return tokenPerShareStored;
     }
     
     /// @notice Refunds any ETH balance held by this contract to the `msg.sender`

--- a/SorbettoFragola.sol
+++ b/SorbettoFragola.sol
@@ -110,7 +110,7 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
     
     /// @notice Prevents calls from users
     modifier onlyGovernance {
-        require(msg.sender == governance, "NA");
+        require(msg.sender == governance, "OG");
         _;
     }
     
@@ -470,8 +470,8 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         uint256 amount0,
         uint256 amount1
     ) external nonReentrant onlyGovernance updateVault(address(0)) {
-        require(accruedProtocolFees0 >= amount0, "A0");
-        require(accruedProtocolFees1 >= amount1, "A1");
+        require(accruedProtocolFees0 >= amount0, "A0F");
+        require(accruedProtocolFees1 >= amount1, "A1F");
         
         uint256 balance0 = _balance0();
         uint256 balance1 = _balance1();
@@ -499,8 +499,8 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
     function collectFees(uint256 amount0, uint256 amount1) external updateVault(msg.sender) {
         UserInfo storage user = userInfo[msg.sender];
 
-        require(user.token0Rewards >= amount0, "A0");
-        require(user.token1Rewards >= amount1, "A1");
+        require(user.token0Rewards >= amount0, "A0R");
+        require(user.token1Rewards >= amount1, "A1R");
 
         uint256 balance0 = _balance0();
         uint256 balance1 = _balance1();

--- a/SorbettoFragola.sol
+++ b/SorbettoFragola.sol
@@ -413,8 +413,7 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         uint256 amount0,
         uint256 amount1,
         bytes calldata data
-    ) external {
-        require(msg.sender == address(pool03));
+    ) external onlyPool {
         MintCallbackData memory decoded = abi.decode(data, (MintCallbackData));
         if (amount0 > 0) pay(token0, decoded.payer, msg.sender, amount0);
         if (amount1 > 0) pay(token1, decoded.payer, msg.sender, amount1);
@@ -429,9 +428,9 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
         int256 amount0,
         int256 amount1,
         bytes calldata _data
-    ) external {
-        require(msg.sender == address(pool03));
-        require(amount0 > 0 || amount1 > 0); // swaps entirely within 0-liquidity regions are not supported
+    ) external onlyPool {
+        // swaps entirely within 0-liquidity regions are not supported
+        require(amount0 > 0 || amount1 > 0, "S0L");
         SwapCallbackData memory data = abi.decode(_data, (SwapCallbackData));
         bool zeroForOne = data.zeroForOne;
 
@@ -531,6 +530,11 @@ contract SorbettoFragola is ERC20Permit, ReentrancyGuard, ISorbettoFragola {
     // when it's too volatile.
     modifier checkDeviation() {
         pool03.checkDeviation(ISorbettoStrategy(strategy).maxTwapDeviation(), ISorbettoStrategy(strategy).twapDuration());
+        _;
+    }
+
+    modifier onlyPool() {
+        require(msg.sender == address(pool03), "FP");
         _;
     }
     

--- a/errorMappings.md
+++ b/errorMappings.md
@@ -1,0 +1,12 @@
+OG - Only Governance is allowed to call this function
+F - Contract is already finalized
+ANV - Must deposit both tokens
+MTS - Max Total Suply exceeded
+S - Must widthdraw more than zero shares
+S0L - Swaps entirely within 0-liquidity regions are not supported
+A0F - Token 0 amount is bigger than accrued protocol fees
+A1F - Token 1 amount is bigger than accrued protocol fees
+A0R - Token 0 amount is bigger than accrued rewards
+A1R - Token 1 amount is bigger than accrued rewards
+PG - You are not nominated for Governance
+RC - Reentrancy not allowed

--- a/errorMappings.md
+++ b/errorMappings.md
@@ -9,4 +9,5 @@ A1F - Token 1 amount is bigger than accrued protocol fees
 A0R - Token 0 amount is bigger than accrued rewards
 A1R - Token 1 amount is bigger than accrued rewards
 PG - You are not nominated for Governance
+FP - Only the pool can call this function
 RC - Reentrancy not allowed

--- a/errorMappings.md
+++ b/errorMappings.md
@@ -11,3 +11,14 @@ A1R - Token 1 amount is bigger than accrued rewards
 PG - You are not nominated for Governance
 FP - Only the pool can call this function
 RC - Reentrancy not allowed
+TS - Invalid Total Supply (needs to be bigger than zero)
+TML - Liquidity burn is bigger than liquidity in pool
+FZA - Sender cannot be the zero address
+TZA - Transfer recipient cannot be the zero address
+MZA - Mint account cannot be the zero address
+BZA - Burn account cannot be the zero address
+AFZA - Approve owner cannot be the zero address
+ATZA - Approve spender cannot be the zero address
+STF - Safe transfer from failed
+ST - Safe transfer failed
+SET - Safe ETH transfer failed

--- a/libraries/PoolActions.sol
+++ b/libraries/PoolActions.sol
@@ -70,7 +70,7 @@ library PoolActions {
         address to
     ) internal returns (uint256 amount0, uint256 amount1) {
         uint128 liquidityInPool = pool.positionLiquidity(tickLower, tickUpper);
-        require(liquidityInPool >= liquidity);
+        require(liquidityInPool >= liquidity, "TML");
         (amount0, amount1) = pool.burn(tickLower, tickUpper, liquidity);
 
         if (amount0 > 0 || amount1 > 0) {


### PR DESCRIPTION
This PR removes `_token0PerShare(uint256 collected0) & _token1PerShare(uint256 collected1)` functions that share exactly the same functionality but use a different variable in their implementation (`token0PerShareStored & token1PerShareStored` respectively), and creates a single new function that receives this different variable as input `_tokenPerShare(uint256 collected, uint256 tokenPerShareStored)`.

Regarding the new implementation of _tokenPerShare: Not sure if passing a flag as an argument and retrieving the right tokenPerShareStored variable would be more gas effective than passing the whole variable as input.

*EDIT:* Also added the Error Code mapping to this PR.